### PR TITLE
Add global Dialog system

### DIFF
--- a/Manzo/Manzo/Engine/DialogSystem.cpp
+++ b/Manzo/Manzo/Engine/DialogSystem.cpp
@@ -1,0 +1,24 @@
+#include "DialogSystem.h"
+
+DialogSystem::DialogSystem()
+{
+    dialog = new Dialog({0,0});
+}
+
+DialogSystem::~DialogSystem()
+{
+    Unload();
+    delete dialog;
+}
+
+Dialog& DialogSystem::GetDialog()
+{
+    return *dialog;
+}
+
+void DialogSystem::Unload()
+{
+    if(dialog) {
+        dialog->Unload();
+    }
+}

--- a/Manzo/Manzo/Engine/DialogSystem.h
+++ b/Manzo/Manzo/Engine/DialogSystem.h
@@ -1,0 +1,14 @@
+#pragma once
+#include "../Game/DialogBox.h"
+
+class DialogSystem {
+public:
+    DialogSystem();
+    ~DialogSystem();
+
+    Dialog& GetDialog();
+    void Unload();
+
+private:
+    Dialog* dialog;
+};

--- a/Manzo/Manzo/Engine/Engine.cpp
+++ b/Manzo/Manzo/Engine/Engine.cpp
@@ -27,7 +27,7 @@ Engine::Engine() :
 #else
     logger(Logger::Severity::Event, false),
 #endif
-    beat(&audiomanager),savedatamanager("assets/jsons/save.json")
+    beat(&audiomanager),savedatamanager("assets/jsons/save.json"), dialogsystem()
 {
     unsigned int seed = static_cast<unsigned int>(std::time(NULL));
     std::srand(seed);
@@ -43,6 +43,7 @@ void Engine::Start(std::string window_title)
 
 void Engine::Stop() {
     logger.LogEvent("Engine Stopped");
+    dialogsystem.Unload();
 }
 
 void Engine::Update() {

--- a/Manzo/Manzo/Engine/Engine.h
+++ b/Manzo/Manzo/Engine/Engine.h
@@ -26,6 +26,7 @@ Created:    March 8, 2023
 #include "SaveDataManager.h"
 #include "EventManager.h"
 #include "ScenarioSystem.h"
+#include "DialogSystem.h"
 
 #include <chrono>
 #include <time.h>
@@ -87,6 +88,10 @@ public:
         return Instance()->eventmanager;
     }
 
+    static DialogSystem& GetDialogSystem() {
+        return Instance()->dialogsystem;
+    }
+
     void Start(std::string window_title);
     void Stop();
     void Update();
@@ -131,4 +136,5 @@ private:
     SaveDataManager savedatamanager;
     Beat beat;
     EventManager eventmanager;
+    DialogSystem dialogsystem;
 };

--- a/Manzo/Manzo/Game/Mode2.cpp
+++ b/Manzo/Manzo/Game/Mode2.cpp
@@ -72,14 +72,14 @@ void Mode2::Load() {
 	// Icon
 	Engine::GetIconManager().LoadIconList();
 
-	// Dialog
-	dialog_ptr = new Dialog({ 0,0 });
-	GetGSComponent<GameObjectManager>()->Add(dialog_ptr);
+	// Dialog from global system
+        Dialog& dialog = Engine::GetDialogSystem().GetDialog();
+        GetGSComponent<GameObjectManager>()->Add(&dialog);
 
 	//Engine::GetLogger().LoadSaveFile();
 
 	//ScenarioComponent
-	scenario = new ScenarioComponent(dialog_ptr);
+	scenario = new ScenarioComponent();
 	AddGSComponent(scenario);
 	scenario->Load();
 
@@ -157,12 +157,12 @@ void Mode2::Update(double dt) {
 	}
 
 	if (Engine::GetInput().KeyJustPressed(Input::Keys::Z) && !isLoaded) {
-		dialog_ptr->LoadDialogGroup("dialog-1", 0.05);
+		Engine::GetDialogSystem().GetDialog().LoadDialogGroup("dialog-1", 0.05);
 		isLoaded = true;
 	}
 	if ((Engine::GetInput().KeyJustPressed(Input::Keys::X) && !isLoaded)) {
 
-		dialog_ptr->LoadRandomDialog("dialog-2", 0.05);
+		Engine::GetDialogSystem().GetDialog().LoadRandomDialog("dialog-2", 0.05);
 		isLoaded = true;
 	}
 #else
@@ -170,20 +170,20 @@ void Mode2::Update(double dt) {
 
 	//Dialog
 	if (Engine::GetInput().KeyJustPressed(Input::Keys::Space)) {
-		dialog_ptr->NextLine();
+		Engine::GetDialogSystem().GetDialog().NextLine();
 	}
 
 
 	if (Engine::GetInput().KeyJustPressed(Input::Keys::C)) {
-		dialog_ptr->Hide();
+		Engine::GetDialogSystem().GetDialog().Hide();
 		isLoaded = false;
 	}
 
-	dialog_ptr->Update(dt);
+	Engine::GetDialogSystem().GetDialog().Update(dt);
 
 	Icon* icon = Engine::GetIconManager().GetCollidingIconWithMouse({ Engine::GetInput().GetMousePos().mouseCamSpaceX ,Engine::GetInput().GetMousePos().mouseCamSpaceY });
 	bool clicked = Engine::GetInput().MouseButtonJustPressed(SDL_BUTTON_LEFT);
-	bool mouse_down = Engine::GetInput().MouseButtonPressed(SDL_BUTTON_LEFT); // ¥©∏£∞Ì ¿÷¥¬¡ˆ »Æ¿Œ
+	bool mouse_down = Engine::GetInput().MouseButtonPressed(SDL_BUTTON_LEFT); // ¬¥¬©¬∏¬£¬∞√≠ √Ä√ñ¬¥√Ç√Å√∂ √à¬Æ√Ä√é
 	bool mouse_released = Engine::GetInput().MouseButtonJustReleased(SDL_BUTTON_LEFT);
 	
 
@@ -272,7 +272,7 @@ void Mode2::Draw() {
 		GetGSComponent<Background>()->Draw(*GetGSComponent<Cam>());
 	}
 	GetGSComponent<GameObjectManager>()->DrawAll();
-	dialog_ptr->Draw();
+	Engine::GetDialogSystem().GetDialog().Draw();
 
 	today_fish_popup->SetPop(true);
 
@@ -378,7 +378,7 @@ void Mode2::Unload() {
 	GetGSComponent<Background>()->Unload();
 	Engine::GetIconManager().Unload();
 	ClearGSComponents();
-	dialog_ptr->Unload();
+	Engine::GetDialogSystem().GetDialog().Unload();
 	playing = false;
 
 	background = nullptr;

--- a/Manzo/Manzo/Game/Mode2.h
+++ b/Manzo/Manzo/Game/Mode2.h
@@ -49,7 +49,6 @@ private:
     Ship* ship_ptr;
     Background* background;
     Shop* shop_ptr;
-    Dialog* dialog_ptr;
     Player* player_ptr;
     Inven* inven_ptr;
     Module* module_ptr;

--- a/Manzo/Manzo/Game/Mode3.cpp
+++ b/Manzo/Manzo/Game/Mode3.cpp
@@ -58,9 +58,9 @@ void Mode3::Load() {
 	ship_ptr = new Ship({0,0});
 	GetGSComponent<GameObjectManager>()->Add(ship_ptr);
 
-    //Dialog
-    dialog_ptr = new Dialog({ 0,0 });
-    GetGSComponent<GameObjectManager>()->Add(dialog_ptr);
+    //Dialog from global system
+    Dialog& dialog = Engine::GetDialogSystem().GetDialog();
+    GetGSComponent<GameObjectManager>()->Add(&dialog);
 
     // Mouse
     GetGSComponent<GameObjectManager>()->Add(new Mouse);
@@ -80,12 +80,12 @@ void Mode3::Update(double dt) {
 
         if (!textDisplay ) {
 
-            dialog_ptr->LoadDialogGroup("tutorial-1", 0.05);
+            Engine::GetDialogSystem().GetDialog().LoadDialogGroup("tutorial-1", 0.05);
             textDisplay = true;
         }
         if (Engine::GetInput().KeyJustPressed(Input::Keys::Space)) {
-            dialog_ptr->NextLine();
-            if (dialog_ptr->IsFinished()) {
+            Engine::GetDialogSystem().GetDialog().NextLine();
+            if (Engine::GetDialogSystem().GetDialog().IsFinished()) {
                 currentPhase = TutorialPhase::Dash;
                 textDisplay = false;
             }
@@ -116,12 +116,12 @@ void Mode3::Update(double dt) {
 
     case TutorialPhase::Done:
         if (!textDisplay) {
-            dialog_ptr->LoadDialogGroup("tutorial-2", 0.05);
+            Engine::GetDialogSystem().GetDialog().LoadDialogGroup("tutorial-2", 0.05);
             textDisplay = true;
         }
         if (Engine::GetInput().KeyJustPressed(Input::Keys::Space)) {
-            dialog_ptr->NextLine();
-            if (dialog_ptr->IsFinished()) {
+            Engine::GetDialogSystem().GetDialog().NextLine();
+            if (Engine::GetDialogSystem().GetDialog().IsFinished()) {
                 auto& save = Engine::GetSaveDataManager().GetSaveData();
                 save.eventsDone.push_back("tutorial_end");
                 Engine::GetSaveDataManager().UpdateSaveData(save);
@@ -150,7 +150,7 @@ void Mode3::Draw() {
         GetGSComponent<Background>()->Draw(*GetGSComponent<Cam>());
     }
     GetGSComponent<GameObjectManager>()->DrawAll();
-    dialog_ptr->Draw();
+    Engine::GetDialogSystem().GetDialog().Draw();
 
 
 }
@@ -170,7 +170,7 @@ void Mode3::Unload() {
     GetGSComponent<Background>()->Unload();
     Engine::GetIconManager().Unload();
     ClearGSComponents();
-    dialog_ptr->Unload();
+    Engine::GetDialogSystem().GetDialog().Unload();
     background = nullptr;
 
 }

--- a/Manzo/Manzo/Game/Mode3.h
+++ b/Manzo/Manzo/Game/Mode3.h
@@ -50,7 +50,6 @@ private:
     Reef* reef_ptr;
     Cam* camera;
     Background* background;
-    Dialog* dialog_ptr;
     double phaseTimer = 0.0;
     bool textDisplay = false;
 

--- a/Manzo/Manzo/Game/ScenarioComponent.cpp
+++ b/Manzo/Manzo/Game/ScenarioComponent.cpp
@@ -1,10 +1,13 @@
 #include "../Engine/GameObjectManager.h"
 #include "../Engine/GameState.h"
 #include "ScenarioComponent.h"
+#include "../Engine/Engine.h"
 #include "NPC.h"
 #include "Mouse.h"
 #include "PopUp.h"
 #include "States.h"
+ScenarioComponent::ScenarioComponent() : dialog(&Engine::GetDialogSystem().GetDialog()) {}
+
 
 void ScenarioComponent::Load()
 {
@@ -107,7 +110,7 @@ void ScenarioComponent::Load()
             return total >= 15;
         },
         []() {
-            std::cout << "¹°°í±â 15¸¶¸® ÀÌº¥Æ® ¿Ï·á!" << std::endl;
+            std::cout << "Â¹Â°Â°Ã­Â±Ã¢ 15Â¸Â¶Â¸Â® Ã€ÃŒÂºÂ¥Ã†Â® Â¿ÃÂ·Ã¡!" << std::endl;
             Engine::GetEventManager().MarkEventDone("catch_15_fish");
 
             auto* popup = new PopUp({ -420,195 }, "assets/images/catch_done_popup.spt", true);
@@ -142,3 +145,5 @@ void ScenarioComponent::Load()
     has_initialized = true;
 }
 
+
+void ScenarioComponent::Unload() {}

--- a/Manzo/Manzo/Game/ScenarioComponent.h
+++ b/Manzo/Manzo/Game/ScenarioComponent.h
@@ -6,8 +6,7 @@
 
 class ScenarioComponent : public Component {
 public:
-    ScenarioComponent(Dialog* dia)
-        : dialog(dia) {}
+    ScenarioComponent();
     void Load();
     void Unload();
 


### PR DESCRIPTION
## Summary
- introduce `DialogSystem` to own a single `Dialog`
- expose `GetDialogSystem()` from `Engine`
- use the global `Dialog` in scenario and modes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d41a8bf2083219ead8989ca1c9f78